### PR TITLE
fix: ensure the Chrome process terminates on error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,7 @@ export default async ({
     ...customOptions
   };
 
-  // we need to kill chrome if something goes wrong, so we pull it
+  // we need to kill chrome if something goes wrong, so we pull it up
   // into the function scope to be accessible in the catch block.
   let chrome;
 

--- a/src/index.js
+++ b/src/index.js
@@ -30,58 +30,71 @@ export default async ({
     ...customOptions
   };
 
-  const chrome = await chromeLauncher.launch({
-    chromeFlags: options.chromeFlags,
-    port: options.port
-  });
+  // we need to kill chrome if something goes wrong, so we pull it
+  // into the function scope to be accessible in the catch block.
+  let chrome;
 
-  options.output = 'html';
-
-  // the default config combined with overriding query params
-  const fullConfig = {
-    ...config,
-    ...customConfig
-  };
-
-  const results = await lighthouse(url, options, fullConfig);
-
-  // a remote URL
-  let report;
-
-  // a local file path
-  let localReport;
-
-  if (isS3) {
-    // upload to S3
-    const s3Response = await upload({
-      s3bucket: new AWS.S3({
-        accessKeyId,
-        Bucket,
-        region,
-        secretAccessKey
-      }),
-      params: {
-        ACL: 'public-read',
-        Body: results.report,
-        Bucket,
-        ContentType: 'text/html',
-        Key: `lighthouse-report-${Date.now()}.html`
-      }
+  try {
+    chrome = await chromeLauncher.launch({
+      chromeFlags: options.chromeFlags,
+      port: options.port
     });
 
-    report = s3Response.Location;
+    options.output = 'html';
+
+    // the default config combined with overriding query params
+    const fullConfig = {
+      ...config,
+      ...customConfig
+    };
+
+    const results = await lighthouse(url, options, fullConfig);
+
+    // a remote URL
+    let report;
+
+    // a local file path
+    let localReport;
+
+    if (isS3) {
+      // upload to S3
+      const s3Response = await upload({
+        s3bucket: new AWS.S3({
+          accessKeyId,
+          Bucket,
+          region,
+          secretAccessKey
+        }),
+        params: {
+          ACL: 'public-read',
+          Body: results.report,
+          Bucket,
+          ContentType: 'text/html',
+          Key: `lighthouse-report-${Date.now()}.html`
+        }
+      });
+
+      report = s3Response.Location;
+    }
+
+    if (outputDirectory) {
+      localReport = `${outputDirectory}/lighthouse-report-${Date.now()}.html`;
+      fs.writeFileSync(localReport, results.report);
+    }
+
+    await chrome.kill();
+
+    return {
+      localReport,
+      result: JSON.parse(JSON.stringify(results.lhr)),
+      report
+    };
+  } catch (error) {
+    // make sure we kill chrome
+    if (chrome) {
+      await chrome.kill();
+    }
+
+    throw error;
   }
-
-  if (outputDirectory) {
-    localReport = `${outputDirectory}/lighthouse-report-${Date.now()}.html`;
-    fs.writeFileSync(localReport, results.report);
-  }
-
-  await chrome.kill();
-
-  return {
-    localReport,
-    result: JSON.parse(JSON.stringify(results.lhr)),
-    report
-  };
 };


### PR DESCRIPTION
# Summary

I have a theory that this will fix the issue raised in #1. Although it's just a theory, this change is an improvement regardless. The **expected** outcome described in the issue is that a consumer such as a GitHub Action will stop execution on error. An error from this module should bubble up and kill the process. I'm not certain about the inner workings of GitHub actions and what causes them to terminate, but perhaps in this case the **actual** outcome is that the Chrome process opened by [Chrome Launcher](https://github.com/GoogleChrome/chrome-launcher) from this module is never closed, because the module throws an exception before executing `chrome.kill()`. And perhaps because the Chrome process is left open, the GitHub Action never terminates.